### PR TITLE
Use HTTPS to avoid Firefox mixed content error

### DIFF
--- a/simple.html
+++ b/simple.html
@@ -4,9 +4,9 @@
 <head>
 <!-- created by Piers Titus van der Torren, 2010 - http://www.toverlamp.org/static/wickisynth/ -->
 	<title>Simple use example of Wicki keyboard and Karplus-Strong synthesizer JavaScript classes</title>
-	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
-	<script src="http://ajax.googleapis.com/ajax/libs/jqueryui/1.8.2/jquery-ui.min.js"></script>
-	<link href="http://ajax.googleapis.com/ajax/libs/jqueryui/1.8.2/themes/base/jquery-ui.css" rel="stylesheet" type="text/css"/>
+	<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
+	<script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.2/jquery-ui.min.js"></script>
+	<link href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.2/themes/base/jquery-ui.css" rel="stylesheet" type="text/css"/>
 	<script src="keyboard.js"></script>
 	<script src="karplusstrong.js"></script>
 	

--- a/wickisynth.html
+++ b/wickisynth.html
@@ -4,9 +4,9 @@
 <head>
 <!-- created by Piers Titus van der Torren, 2010 - http://www.toverlamp.org/static/wickisynth/ -->
 	<title>Tuning exploration, Wicki keyboard and Karplus-Strong synthesizer</title>
-	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
-	<script src="http://ajax.googleapis.com/ajax/libs/jqueryui/1.8.2/jquery-ui.min.js"></script>
-	<link href="http://ajax.googleapis.com/ajax/libs/jqueryui/1.8.2/themes/base/jquery-ui.css" rel="stylesheet" type="text/css"/>
+	<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
+	<script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.2/jquery-ui.min.js"></script>
+	<link href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.2/themes/base/jquery-ui.css" rel="stylesheet" type="text/css"/>
 	<script src="raphael-min.js"></script>
 
 	<script src="keyboard.js"></script>

--- a/wickisynth_lowlatency.html
+++ b/wickisynth_lowlatency.html
@@ -4,9 +4,9 @@
 <head>
 <!-- created by Piers Titus van der Torren, 2010 - http://www.toverlamp.org/static/wickisynth/ -->
 	<title>Tuning exploration, Wicki keyboard and Karplus-Strong synthesizer</title>
-	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
-	<script src="http://ajax.googleapis.com/ajax/libs/jqueryui/1.8.2/jquery-ui.min.js"></script>
-	<link href="http://ajax.googleapis.com/ajax/libs/jqueryui/1.8.2/themes/base/jquery-ui.css" rel="stylesheet" type="text/css"/>
+	<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
+	<script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.2/jquery-ui.min.js"></script>
+	<link href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.2/themes/base/jquery-ui.css" rel="stylesheet" type="text/css"/>
 	<script src="raphael-min.js"></script>
 
 	<script src="keyboard.js"></script>


### PR DESCRIPTION
Hi Piers!

I've been making good use of your Wickisynth while working on that theory illustration that I emailed about, but today I received an error from the tovarlamp site (Firefox 87). I believe this should fix things. 

BTW, any further prognosis as to the availability of any extra Striso Boards post-QA processes? I am still very much interested in purchasing one.